### PR TITLE
Added retrieval of hive type using enum

### DIFF
--- a/Registry/Registry.py
+++ b/Registry/Registry.py
@@ -22,7 +22,7 @@ import sys
 import ntpath
 from enum import Enum
 
-import RegistryParse
+from . import RegistryParse
 
 RegSZ = 0x0001
 RegExpandSZ = 0x0002


### PR DESCRIPTION
I notice that you tend to minimise imports, though I am not sure whether that is an actual decision or just that you rarely need them, however, I have used the "enum34" library to implement "proper" enums which have been introduced to python 3.

https://pypi.python.org/pypi/enum34

So users need to "sudo pip install enum34" before using
