### PR TITLE
Fix MSB check in data_length method

### DIFF
--- a/Registry/RegistryParse.py
+++ b/Registry/RegistryParse.py
@@ -730,7 +730,7 @@ class VKRecord(Record):
         Get the length of this value data. This is the actual length of the data that should be parsed for the value.
         """
         size = self.unpack_dword(0x4)
-        if size > 0x80000000:
+        if size >= 0x80000000:
             size -= 0x80000000
         return size
 


### PR DESCRIPTION
In data_length method, if statement checks > 0x80000000. This is a check for the most significant bit being set so should be >= 0x80000000.