### PR TITLE
Added 'unicodecsv' to setup.py 'install_requires' list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(name='python-registry',
                      "Programming Language :: Python :: 3",
                      "Operating System :: OS Independent", 
                      "License :: OSI Approved :: Apache Software License"],
-     install_requires=["enum34"]
+     install_requires=['enum34','unicodecsv']
      )
 


### PR DESCRIPTION
Hey Willi--

While attempting to run amcache.py on a newer machine, I still needed to install the ```unicodecsv``` module after executing the python-registry setup script:

```
dev@computer:~/python-registry$ python samples/amcache.py -h
Traceback (most recent call last):
  File "samples/amcache.py", line 24, in <module>
    import unicodecsv
ImportError: No module named unicodecsv
```

If you don't mind, I went ahead and added ```unicodecsv``` to the setup script. Everything was smooth-sailing after that:

```
dev@computer:~/python-registry$ python samples/amcache.py -h
usage: amcache.py [-h] [-v] [-t] registry_hive

Parse program execution entries from the Amcache.hve Registry hive

positional arguments:
  registry_hive  Path to the Amcache.hve hive to process

optional arguments:
  -h, --help     show this help message and exit
  -v             Enable verbose output
  -t             Output in simple timeline format
```

Thanks!

Adam