### PR TITLE
Added JSON-Formatted Output

### DIFF
--- a/samples/amcache.py
+++ b/samples/amcache.py
@@ -19,6 +19,7 @@ import sys
 import logging
 import datetime
 from collections import namedtuple
+import json
 
 import argparse
 import unicodecsv
@@ -175,6 +176,8 @@ def main(argv=None):
                         help="Enable verbose output")
     parser.add_argument("-t", action="store_true", dest="do_timeline",
                         help="Output in simple timeline format")
+    parser.add_argument("-j", action="store_true", dest="do_json",
+                        help="Output in JSON-formatted strings")
     args = parser.parse_args(argv[1:])
 
     if args.verbose:
@@ -213,6 +216,19 @@ def main(argv=None):
         w.writerow(["timestamp", "timestamp_type", "path", "sha1"])
         for e in sorted(entries, key=lambda e: e.timestamp):
             w.writerow([e.timestamp, e.type, e.entry.path, e.entry.sha1])
+
+    elif args.do_json:
+        for e in ee:
+            document = {}
+            for i in FIELDS:
+                document[i.name] = getattr(e, i.name)
+                if document[i.name] is None:
+                    document[i.name] = "-"
+                elif type(document[i.name]) == datetime.datetime:
+                    document[i.name] = str(document[i.name])
+
+            print json.dumps(document, ensure_ascii=False).encode("utf8")
+
     else:
         w = unicodecsv.writer(sys.stdout, delimiter="|", quotechar="\"",
                               quoting=unicodecsv.QUOTE_MINIMAL, encoding="utf-8")

--- a/samples/amcache.py
+++ b/samples/amcache.py
@@ -227,7 +227,7 @@ def main(argv=None):
                 elif type(document[i.name]) == datetime.datetime:
                     document[i.name] = str(document[i.name])
 
-            print json.dumps(document, ensure_ascii=False).encode("utf8")
+            print json.dumps(document, ensure_ascii=False).encode("utf-8")
 
     else:
         w = unicodecsv.writer(sys.stdout, delimiter="|", quotechar="\"",

--- a/samples/amcache.py
+++ b/samples/amcache.py
@@ -15,6 +15,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
+from __future__ import print_function
 import sys
 import logging
 import datetime
@@ -227,7 +229,7 @@ def main(argv=None):
                 elif type(document[i.name]) == datetime.datetime:
                     document[i.name] = str(document[i.name])
 
-            print json.dumps(document, ensure_ascii=False).encode("utf-8")
+            print(json.dumps(document, ensure_ascii=False).encode("utf-8"))
 
     else:
         w = unicodecsv.writer(sys.stdout, delimiter="|", quotechar="\"",


### PR DESCRIPTION
Greets--

Short: This pull request adds functionality to output results as JSON-formatted strings with the ```-j``` command-line switch.

Long:
amcache.py would be a great tool to use when sampling an environment for Amcache.hve artifacts at scale. I have considered various ways to consume and log the data parsed by amcache.py: shipping to Elasticsearch or Logstash (via syslog/filebeat), or perhaps by interpreting the data with other Python scripts.

Of the options I have considered, JSON-formatted output would be extremely valuable - for example, in Logstash the syslog and beats plugins contain codec functionality for JSON-formatted events. Similarly, other Python scripts could benefit from JSON-formatted strings by loading them as dictionary objects to access and act upon the various key/value combinations.

Sample output:

```
dev@computer:~/python-registry$ python samples/amcache.py Amcache.hve -j

{"pe_checksum": 161438, "modified_timestamp": "2013-08-22 13:25:38.066004", "sha1": "0000f783a29297a42e86e7f2ef17d91737eb5add732d", "pe_sizeofimage": 143360, "first_run": "2014-11-21 09:54:02.063293", "language": 1033, "linker_timestamp": "2013-08-22 02:47:53", "company": "Microsoft Corporation", "switchbackcontext": 72057594037929472, "product": "Microsoft® Windows® Operating System", "header_hash": "0101c6ba8c455c8332340bc4a73f782f15b427336eff", "modified_timestamp2": "2013-08-22 13:25:38.053610", "version": "6.3.9600.16384 (winblue_rtm.130821-1623)", "id": "-", "file_description": "Dism Host Servicing Process", "created_timestamp": "2014-11-21 09:54:01.969542", "path": "C:\\Users\\Administrator\\AppData\\Local\\Temp\\9D1571B1-DEC2-4D4D-8166-81378BC8398F\\DismHost.exe", "version_number": "6.3.9600.16384", "size": 140392}
```

Note: I am highly inadequate when it comes to handling unicode strings, but found a combination of methods that seemed to do the job. I would appreciate any further testing to ensure it works consistent with the rest of your project.

Thanks!

Adam
Tw: [@_TrapLoop](https://twitter.com/_TrapLoop)