### PR TITLE
Small typo (modification of "g_logging" by "g_logger") in amcache.py

### DIFF
--- a/samples/amcache.py
+++ b/samples/amcache.py
@@ -191,7 +191,7 @@ def main(argv=None):
     try:
         ee = parse_execution_entries(r)
     except NotAnAmcacheHive:
-        g_logging.error("doesn't appear to be an Amcache.hve hive")
+        g_logger.error("doesn't appear to be an Amcache.hve hive")
         return
 
     if args.do_timeline:


### PR DESCRIPTION
Small typo (modification of "g_logging" by "g_logger") in [amcache.py](https://github.com/williballenthin/python-registry/blob/master/samples/amcache.py)  to avoid the error
```
    g_logging.error("doesn't appear to be an Amcache.hve hive")
NameError: name 'g_logging' is not defined
```