### PR TITLE
Fixes bug in Python 3 getting raw_data() from certain Record types

### DIFF
--- a/Registry/RegistryParse.py
+++ b/Registry/RegistryParse.py
@@ -679,7 +679,7 @@ class DBIndirectBlock(Record):
 
             count += 1
             length -= size
-        return str(b)
+        return bytes(b)
 
 
 class DBRecord(Record):
@@ -732,7 +732,7 @@ def decode_utf16le(s):
     if b"\x00\x00" in s:
         index = s.index(b"\x00\x00")
         if index > 2:
-            if s[index - 2] != b"\x00"[0]: #py2+3 
+            if s[index - 2] != b"\x00"[0]: #py2+3
                 #  61 00 62 00 63 64 00 00
                 #                    ^  ^-- end of string
                 #                    +-- index
@@ -1378,7 +1378,7 @@ class NKRecord(Record):
           """
           Return the full path of the registry key as a unicode string
           @return: unicode string containing the path
-          """ 
+          """
           p = self
 
           name = [p.name()]
@@ -1390,7 +1390,7 @@ class NKRecord(Record):
                   break
               name.append(p.name())
               offsets.add(p._offset)
-          return '\\'.join(reversed(name))  
+          return '\\'.join(reversed(name))
 
     def is_root(self):
         """

--- a/tests/test_large_data.py
+++ b/tests/test_large_data.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import hashlib
+import os
+import unittest
+
+from Registry import Registry
+
+
+class TestRegistryLargeData(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'testing', 'reg_samples', 'new_log_1', 'SYSTEM')
+
+    def test_large_data(self):
+        root = Registry.Registry(self.path).root()
+        value = root.find_key(r'ControlSet001\Control\ProductOptions').value('ProductPolicy')
+        data = value.raw_data()
+        self.assertEqual(bytes, type(data))
+        self.assertEqual(23712, len(data))
+        self.assertEqual('7e96f10f77e1c44771d7045c24b94024', hashlib.md5(data).hexdigest())
+
+# Run Tests
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Specifically: DBIndirectBlock.large_data should return `bytes`, not `str`, in Python 3. In Python 2, `bytes` and `str` are the same type.