### PR TITLE
Fix rounding error in RegistryParse.parse_windows_timestamp

### DIFF
--- a/Registry/RegistryParse.py
+++ b/Registry/RegistryParse.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 
 import struct
 from datetime import datetime
+import decimal
 import binascii
 from ctypes import c_uint32
 from enum import Enum
@@ -60,9 +61,38 @@ DEVPROP_MASK_TYPE = 0x00000FFF
 # This named tuple describes the recovery operations to be performed on a hive.
 RecoveryStatus = namedtuple('RecoveryStatus', ['recover_header', 'recover_data'])
 
+
+def parse_timestamp(qword, resolution, epoch_shift, mode=decimal.ROUND_HALF_EVEN):
+    """
+    Generalized function for parsing timestamps
+
+    :param qword: number of time units since the epoch
+    :param resolution: number of time units per second
+    :param epoch_shift: difference in seconds between UNIX epoch (1970-1-1)
+                        and epoch of qword
+    :param mode: decimal rounding mode
+    :return: datetime.datetime
+    """
+    # convert qword from given epoch to UNIX epoch
+    shifted = qword - epoch_shift * resolution
+    # python's datetime.datetime supports microsecond precision
+    datetime_resolution = int(1e6)
+
+    # total number of microseconds since UNIX epoch
+    # python 3 round() returns int, python 2 round() returns float
+    total_microseconds = (decimal.Decimal(shifted * datetime_resolution) / decimal.Decimal(resolution)).quantize(1, mode)
+
+    # convert to datetime
+    return datetime.utcfromtimestamp(total_microseconds // datetime_resolution).replace(microsecond=total_microseconds % datetime_resolution)
+
+
 def parse_windows_timestamp(qword):
-    # see http://integriography.wordpress.com/2010/01/16/using-phython-to-parse-and-present-windows-64-bit-timestamps/
-    return datetime.utcfromtimestamp(float(qword) * 1e-7 - 11644473600 )
+    """
+    :param qword: number of 100-nanoseconds since 1601-01-01
+    :return: datetime.datetime
+    """
+    # see https://msdn.microsoft.com/en-us/library/windows/desktop/ms724290(v=vs.85).aspx
+    return parse_timestamp(qword, int(1e7), 11644473600)
 
 
 class RegistryException(Exception):
@@ -732,7 +762,7 @@ def decode_utf16le(s):
     if b"\x00\x00" in s:
         index = s.index(b"\x00\x00")
         if index > 2:
-            if s[index - 2] != b"\x00"[0]: #py2+3 
+            if s[index - 2] != b"\x00"[0]: #py2+3
                 #  61 00 62 00 63 64 00 00
                 #                    ^  ^-- end of string
                 #                    +-- index
@@ -1378,7 +1408,7 @@ class NKRecord(Record):
           """
           Return the full path of the registry key as a unicode string
           @return: unicode string containing the path
-          """ 
+          """
           p = self
 
           name = [p.name()]
@@ -1390,7 +1420,7 @@ class NKRecord(Record):
                   break
               name.append(p.name())
               offsets.add(p._offset)
-          return '\\'.join(reversed(name))  
+          return '\\'.join(reversed(name))
 
     def is_root(self):
         """

--- a/tests/test_parse_timestamp.py
+++ b/tests/test_parse_timestamp.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import datetime
+import unittest
+
+from Registry.RegistryParse import parse_windows_timestamp
+
+
+class TestParseTimestamp(unittest.TestCase):
+    def test_parse_timestamp(self):
+        tests = {
+            # Rounding error in old floating point calculation, which gave 2016-7-14 10:40:00.041864)
+            131132256000418650: datetime.datetime(2016, 7, 17, 10, 40, 0, 41865),
+            # This actually rounds up to microseconds=041866 using 64-bit floating point arithmetic
+            131132256000418654: datetime.datetime(2016, 7, 17, 10, 40, 0, 41865),
+            # Unix epoch
+            116444736000000000: datetime.datetime(1970, 1, 1, 0, 0, 0, 0),
+            # Rounding up to next second
+            116444736009999996: datetime.datetime(1970, 1, 1, 0, 0, 1, 0),
+            # Rounding the last digit which doesn't fit into datetime.microseconds
+            116444736000000006: datetime.datetime(1970, 1, 1, 0, 0, 0, 1),
+            # round up to even
+            116444736000000015: datetime.datetime(1970, 1, 1, 0, 0, 0, 2),
+            # round down to even
+            116444736000000005: datetime.datetime(1970, 1, 1, 0, 0, 0, 0),
+        }
+
+        for timestamp, expected in tests.items():
+            actual = parse_windows_timestamp(timestamp)
+            self.assertEqual(expected, actual, msg='{}: {}!={}'.format(timestamp, expected, actual))
+
+
+# Run Tests
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_reorganized_values.py
+++ b/tests/test_reorganized_values.py
@@ -18,7 +18,7 @@ class TestReorganizedValues(unittest.TestCase):
 
     def test_timestamp(self):
         timestamp = Registry.Registry(self.path)._regf.reorganized_timestamp()
-        assert(timestamp == datetime(2016, 7, 17, 10, 40, 0, 41864))
+        self.assertEqual(datetime(2016, 7, 17, 10, 40, 0, 41865), timestamp)
 
 # Run Tests
 if __name__ == '__main__':


### PR DESCRIPTION
This change ensures that `parse_windows_timestamp` is accurate to the microsecond.

Currently, there's some loss of precision using floating point arithmetic, as 64-bit floats just don't contain enough precision for typical windows timestamps.

It's possible to improve the current implementation without using `decimal`, by delaying the conversion to floating point. Namely, changing L83 below to: `total_microseconds = int(round((shifted * datetime_resolution) / resolution))`. That gives better results, but still results in some rounding error (see the second test case).

I've implemented this change using a generalized `parse_timestamp` function, which could perhaps be used with other epochs/timestamp resolutions if the need arises?

This may break some existing tests/tools which rely on the old rounding method.