### PR TITLE
Add optional read length/overrun parameter on Values

### DIFF
--- a/Registry/Registry.py
+++ b/Registry/Registry.py
@@ -156,11 +156,11 @@ class RegistryValue(object):
         """
         return self._vkrecord.data_type_str()
 
-    def value(self):
-        return self._vkrecord.data()
+    def value(self, overrun=0):
+        return self._vkrecord.data(overrun)
 
-    def raw_data(self):
-        return self._vkrecord.raw_data()
+    def raw_data(self, overrun=0):
+        return self._vkrecord.raw_data(overrun)
 
 
 class RegistryKey(object):

--- a/Registry/RegistryParse.py
+++ b/Registry/RegistryParse.py
@@ -1047,10 +1047,15 @@ class VKRecord(Record):
         """
         data_type = self.data_type()
         data_length = self.raw_data_length()
-        d = self.raw_data(overrun)
+        d = self.raw_data(overrun=overrun)
 
         if data_type == RegSZ or data_type == RegExpandSZ:
-            return d.decode('utf16')  #decode_utf16le(d)
+            if overrun > 0:
+                # decode_utf16le() only returns the first string, but if we explicitly
+                # ask for overrun, let's make a best-effort to decode as much as possible.
+                return d.decode('utf16')
+            else:
+                return decode_utf16le(d)
         elif data_type == RegBin or data_type == RegNone:
             return d
         elif data_type == RegDWord:


### PR DESCRIPTION
This optional parameter allows reading back arbitrary length data from a Value, including overrunning the current data length. This is useful for forensic analysis applications that may wish to examine overwritten key data. Values are non-truncating, thus will preserve old data in the slack space if overwritten by a smaller length value.