### PR TITLE
Replace enum34 with enum-compat to allow use with Py3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(name='python-registry',
                      "Programming Language :: Python :: 3",
                      "Operating System :: OS Independent", 
                      "License :: OSI Approved :: Apache Software License"],
-     install_requires=['enum34','unicodecsv']
+     install_requires=['enum-compat','unicodecsv']
      )
 


### PR DESCRIPTION
Use enum-compat instead of enum34 as dependency. enum-compat checks version and installs either enum34 for Python 2.7 - 3.3 or does nothing for 3.4+.