### PR TITLE
Add __repr__ method

### DIFF
--- a/Registry/Registry.py
+++ b/Registry/Registry.py
@@ -107,6 +107,9 @@ class RegistryValue(object):
     def __init__(self, vkrecord):
         self._vkrecord = vkrecord
 
+    def __repr__(self):
+        return f"RegistryValue(name={self.name()}, value={self.value()}, type={self.value_type_str()})"
+
     def name(self):
         """
         Get the name of the value as a string.
@@ -252,6 +255,9 @@ class RegistryKey(object):
         return "Registry Key %s with %d values and %d subkeys" % \
             (self.path(), len(self.values()), len(self.subkeys()))
 
+    def __repr__(self):
+        return f"RegistryKey(name={self.name()}, path={self.path()})" 
+
     def __getitem__(self, key):
         return self.value(key)
 
@@ -387,6 +393,9 @@ class Registry(object):
             with open(filelikeobject, "rb") as f:
                 self._buf = f.read()
         self._regf = RegistryParse.REGFBlock(self._buf, 0, False)
+
+    def __repr__(self):
+        return f"Registry(hive_name={self.hive_name()}, hive_type={self.hive_type()})"
 
     def hive_name(self):
         """Returns the internal file name"""

--- a/Registry/Registry.py
+++ b/Registry/Registry.py
@@ -258,8 +258,6 @@ class RegistryKey(object):
     def __repr__(self):
         return 'RegistryKey(name="{0}", path="{1}")'.format(self.name(), self.path())
     
-    def __repr__(self):
-        return f"RegistryKey(name={self.name()}, path={self.path()})" 
 
     def __getitem__(self, key):
         return self.value(key)

--- a/Registry/Registry.py
+++ b/Registry/Registry.py
@@ -108,8 +108,8 @@ class RegistryValue(object):
         self._vkrecord = vkrecord
 
     def __repr__(self):
-        return f"RegistryValue(name={self.name()}, value={self.value()}, type={self.value_type_str()})"
-
+        return 'RegistryValue(name="{0}", value="{1}", type="{2}")'.format(self.name(), self.value(), self.value_type_str())
+        
     def name(self):
         """
         Get the name of the value as a string.
@@ -256,6 +256,9 @@ class RegistryKey(object):
             (self.path(), len(self.values()), len(self.subkeys()))
 
     def __repr__(self):
+        return 'RegistryKey(name="{0}", path="{1}")'.format(self.name(), self.path())
+    
+    def __repr__(self):
         return f"RegistryKey(name={self.name()}, path={self.path()})" 
 
     def __getitem__(self, key):
@@ -395,8 +398,8 @@ class Registry(object):
         self._regf = RegistryParse.REGFBlock(self._buf, 0, False)
 
     def __repr__(self):
-        return f"Registry(hive_name={self.hive_name()}, hive_type={self.hive_type()})"
-
+        return 'Registry(hive_name="{0}", hive_type="{1}")'.format(self.hive_name(), self.hive_type())
+    
     def hive_name(self):
         """Returns the internal file name"""
         return self._regf.hive_name()


### PR DESCRIPTION
Hello.  Thank you for this module.  It is IMHO the best module available for parsing registry files.   Would you please consider accepting this pull request to add a `__repr__` method to the objects?  This will make understanding variables in debugger watch lists, ipython, jupyter notebooks and other interactive python sessions much easier.

So we get this...
```
>> from Registry.Registry import Registry
>>> hive = Registry("NTUSER.DAT")
>>> hive
Registry(hive_name=??\C:\Users\Win10Lab\ntuser.dat, hive_type=HiveType.NTUSER)
>>> key = hive.open(r"Software\Microsoft\Windows\CurrentVersion\Run")
>>> key
RegistryKey(name=Run, path=ROOT\SOFTWARE\Microsoft\Windows\CurrentVersion\Run)
>>> key.values()
[RegistryValue(name=OneDrive, value="C:\Users\Win10Lab\AppData\Local\Microsoft\OneDrive\OneDrive.exe" /background, type=RegSZ)]**
>>> hive.root().subkeys()
[RegistryKey(name=AppEvents, path=ROOT\AppEvents), RegistryKey(name=AppXBackupContentType, path=ROOT\AppXBackupContentType), RegistryKey(name=Console, path=ROOT\Console), RegistryKey(name=Control Panel, path=ROOT\Control Panel), RegistryKey(name=Environment, path=ROOT\Environment), RegistryKey(name=EUDC, path=ROOT\EUDC), RegistryKey(name=Keyboard Layout, path=ROOT\Keyboard Layout), RegistryKey(name=Network, path=ROOT\Network), RegistryKey(name=Printers, path=ROOT\Printers), RegistryKey(name=SOFTWARE, path=ROOT\SOFTWARE), RegistryKey(name=System, path=ROOT\System)]
```

Instead of this..

```
>>> from Registry.Registry import Registry
>>> hive = Registry("NTUSER.DAT")
>>> hive
<Registry.Registry.Registry object at 0x7f76ca6bfc88>
>>> key = hive.open(r"Software\Microsoft\Windows\CurrentVersion\Run")
>>> key
<Registry.Registry.RegistryKey object at 0x7f76ca025470>
>>> key.values()
[<Registry.Registry.RegistryValue object at 0x7f76ca0252e8>]
>>> hive.root().subkeys()
[<Registry.Registry.RegistryKey object at 0x7f76ca0253c8>, <Registry.Registry.RegistryKey object at 0x7f76ca01d198>, <Registry.Registry.RegistryKey object at 0x7f76ca01dc88>, <Registry.Registry.RegistryKey object at 0x7f76ca01de10>, <Registry.Registry.RegistryKey object at 0x7f76ca01dc50>, <Registry.Registry.RegistryKey object at 0x7f76ca01dcf8>, <Registry.Registry.RegistryKey object at 0x7f76ca01dd68>, <Registry.Registry.RegistryKey object at 0x7f76ca01dba8>, <Registry.Registry.RegistryKey object at 0x7f76ca01d9e8>, <Registry.Registry.RegistryKey object at 0x7f76ca01d908>, <Registry.Registry.RegistryKey object at 0x7f76ca01d978>]
```

