### PR TITLE
Enable sample applications as setup.py's entry points

### DIFF
--- a/samples/amcache.py
+++ b/samples/amcache.py
@@ -220,6 +220,8 @@ def main(argv=None):
         for e in ee:
             w.writerow(map(lambda i: getattr(e, i.name), FIELDS))
 
+def _main():
+    main(argv=sys.argv)
 
 if __name__ == "__main__":
-    main(argv=sys.argv)
+    main()

--- a/samples/forensicating.py
+++ b/samples/forensicating.py
@@ -300,7 +300,7 @@ def users_info(soft_reg):
         print(line)
 
 
-if __name__ == "__main__":
+def main():
     """
     Print out all of the information
     """            
@@ -317,3 +317,7 @@ if __name__ == "__main__":
     network_settings(sys_reg, soft_reg)
     users_info(soft_reg)
     user_reg_locs(users_paths(soft_reg, users_sids(soft_reg)))
+
+if __name__ == "__main__":
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,13 @@ setup(name='python-registry',
                      "Programming Language :: Python :: 3",
                      "Operating System :: OS Independent",
                      "License :: OSI Approved :: Apache Software License"],
-     install_requires=['enum-compat']
+     install_requires=['enum-compat'],
+     entry_points = {
+         "console_scripts": [
+             "forensicating.py = samples.forensicating:main",
+             "amcache.py = samples.amcache:main",
+             "registry-timeline.py = samples.timeline:main",
+         ]
+     }
      )
 


### PR DESCRIPTION
Hello Willi 👋 

This PR enables `setup.py` to install some of the sample applications into the `$PATH`, that way, they are directly available after a `pip install` without having to find the path to the samples/ folders 🚀 

I would have prefer to prefix their names with something unique but I had the writer's block :)

If you want me to add the other applications as well, no problem!

